### PR TITLE
Fix typos in job titles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@ export default {
         {
           company: "Genuine Digital School",
           icon: "https://s3-us-west-2.amazonaws.com/peaku-public/business/Company/logo_url/530708/Logo-Genuine-Digital-School.jpg",
-          name: "Profesor de tecnologéa",
+          name: "Profesor de tecnología",
           location: "Remoto",
           salary: "Confidencial",
           vacancies: 1,
@@ -49,7 +49,7 @@ export default {
         {
           company: "Genuine Digital School",
           icon: "https://s3-us-west-2.amazonaws.com/peaku-public/business/Company/logo_url/530708/Logo-Genuine-Digital-School.jpg",
-          name: "Líder de tecnologéa",
+          name: "Líder de tecnología",
           location: "Remoto",
           salary: "Confidencial",
           vacancies: 1,


### PR DESCRIPTION
This pull request fixes typos in the job titles of the App.vue file. The word "tecnologéa" has been corrected to "tecnología" in the "Profesor de tecnología" and "Líder de tecnología" job titles.